### PR TITLE
docs: remove function from nuxt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export default defineNuxtConfig({
   featureFlags: {
     contextPath: '~/feature-flags.context',
     flags: {
-      experimentalFeature: (context) => context.user?.isBetaTester
+      experimentalFeature: false
     },
     defaultContext: {
       environment: process.env.NODE_ENV


### PR DESCRIPTION
functions from nuxt config can’t be serialised into runtime config

you should probably disallow this at the type level as well