### PR TITLE
feat: add file existence check for feature flags configuration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs'
 import { defu } from 'defu'
 import { defineNuxtModule, createResolver, addImports, addPlugin, addTypeTemplate } from '@nuxt/kit'
 import type { FeatureFlagsConfig } from './runtime/types'
@@ -23,10 +22,6 @@ export default defineNuxtModule<FeatureFlagsConfig>({
       try {
         consolador.info('Loading feature flags from:', options.config)
         const { config: configFlags, configFile } = await loadConfigFile(options.config, nuxt.options.rootDir)
-
-        if (!existsSync(configFile!)) {
-          throw new Error(`${configFile} does not exist`)
-        }
 
         consolador.info('Loaded feature flags:', configFlags)
         options.flags = defu(options.flags, configFlags || {})

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,7 +22,6 @@ export default defineNuxtModule<FeatureFlagsConfig>({
       try {
         consolador.info('Loading feature flags from:', options.config)
         const { config: configFlags, configFile } = await loadConfigFile(options.config, nuxt.options.rootDir)
-
         consolador.info('Loaded feature flags:', configFlags)
         options.flags = defu(options.flags, configFlags || {})
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { defu } from 'defu'
 import { defineNuxtModule, createResolver, addImports, addPlugin, addTypeTemplate } from '@nuxt/kit'
 import type { FeatureFlagsConfig } from './runtime/types'
@@ -22,6 +23,11 @@ export default defineNuxtModule<FeatureFlagsConfig>({
       try {
         consolador.info('Loading feature flags from:', options.config)
         const { config: configFlags, configFile } = await loadConfigFile(options.config, nuxt.options.rootDir)
+
+        if (!existsSync(configFile!)) {
+          throw new Error(`${configFile} does not exist`)
+        }
+
         consolador.info('Loaded feature flags:', configFlags)
         options.flags = defu(options.flags, configFlags || {})
 

--- a/src/runtime/core/config-loader.ts
+++ b/src/runtime/core/config-loader.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { loadConfig } from 'c12'
 
 import type { FlagDefinition } from '../types'
@@ -5,7 +6,13 @@ import { consolador } from '../logger'
 
 export async function loadConfigFile(configPath: string, cwd: string) {
   try {
-    return loadConfig<FlagDefinition>({ configFile: configPath.replace(/\.\w+$/, ''), cwd })
+    const config = await loadConfig<FlagDefinition>({ configFile: configPath.replace(/\.\w+$/, ''), cwd })
+
+    if (!existsSync(config.configFile!)) {
+      throw new Error(`${config.configFile} does not exist`)
+    }
+
+    return config
   }
   catch (error) {
     consolador.error('Failed to load config file:', error)


### PR DESCRIPTION
This change throws an error when a config file is specified but the file doesn't exist.

By default `c12.loadConfig` doesn't actually check whether the file exists or not (by design). We need to do this check ourselves.