### PR TITLE
fix: update import path for FlagsSchema in feature-flags.ts

### DIFF
--- a/src/runtime/app/composables/feature-flags.ts
+++ b/src/runtime/app/composables/feature-flags.ts
@@ -1,5 +1,5 @@
 import { useRequestFetch, useState } from '#imports'
-import type { FlagsSchema } from '#feature-flags'
+import type { FlagsSchema } from '#feature-flags/types'
 
 export function useFeatureFlags() {
   const flags = useState<FlagsSchema>('feature-flags', () => ({}))


### PR DESCRIPTION
This correctly imports the `FlagsSchema` type to provider proper runtime type safety.