### PR TITLE
fix: getFeatureFlags doesn't have to be awaited

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const { isEnabled } = useFeatureFlags()
 ```ts
 // server/api/dashboard.ts
 export default defineEventHandler(async (event) => {
-  const { isEnabled } = await getFeatureFlags(event)
+  const { isEnabled } = getFeatureFlags(event)
 
   if (!isEnabled('newDashboard')) {
     throw createError({


### PR DESCRIPTION
`getFeatureFlags` doesn't do anything async, so we don't have to await it