### PR TITLE
fix: handle function-based feature flag configs properly

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,10 +1,14 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
+  
+  compatibilityDate: '2025-02-21',
+  
+  future: {
+    compatibilityVersion: 4,
+  },
 
   components: true,
   devtools: { enabled: true },
-
-  compatibilityDate: '2025-02-21',
 
   featureFlags: {
     config: './feature-flags.config.ts',

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,7 +27,9 @@ export default defineNuxtModule<FeatureFlagsConfig>({
 
     nuxt.options.alias['#feature-flags/types'] = './types/nuxt-feature-flags.d.ts'
     nuxt.options.alias['#feature-flags/handler'] = resolver.resolve('./runtime/server/handlers/feature-flags')
-    nuxt.options.alias['#feature-flags/config'] = resolver.resolve('./runtime/feature-flags.config') // default config
+    
+    // Create default config that handles inline flags properly
+    let configPath = resolver.resolve('./runtime/feature-flags.config')
 
     // Load feature flags configuration from file so that we can generated types from them
     if (options.config) {
@@ -49,12 +51,14 @@ export default defineNuxtModule<FeatureFlagsConfig>({
         }
 
         options.flags = defu(options.flags, configFlags || {})
-        nuxt.options.alias['#feature-flags/config'] = configFile!
+        configPath = configFile!
       }
       catch (error) {
         logger.error('Failed to load feature flags configuration:', error)
       }
     }
+    
+    nuxt.options.alias['#feature-flags/config'] = configPath
 
     addServerImportsDir(resolver.resolve('./runtime/server/utils'))
     addPlugin(resolver.resolve('./runtime/app/plugins/feature-flag.server'))

--- a/src/runtime/app/composables/feature-flags.ts
+++ b/src/runtime/app/composables/feature-flags.ts
@@ -5,12 +5,14 @@ export function useFeatureFlags() {
   const flags = useState<FlagsSchema>('feature-flags', () => ({}))
 
   const fetch = async () => {
-    flags.value = await useRequestFetch()('/api/_feature-flags/feature-flags', {
+    const response = await useRequestFetch()('/api/_feature-flags/feature-flags', {
       headers: {
         accept: 'application/json',
       },
       retry: false,
-    }).catch(() => ({}))
+    }).catch(() => ({ flags: {} }))
+    
+    flags.value = response.flags || {}
   }
 
   return {

--- a/src/runtime/feature-flags.config.ts
+++ b/src/runtime/feature-flags.config.ts
@@ -4,5 +4,9 @@ import { defineFeatureFlags } from '#feature-flags/handler'
 export default defineFeatureFlags(() => {
   const runtimeConfig = useRuntimeConfig()
 
-  return runtimeConfig.public.featureFlags.flags || {}
+  // For inline flags, they're stored directly in featureFlags.flags
+  // For config file flags, they're merged and available as the entire featureFlags object
+  const flags = runtimeConfig.public.featureFlags?.flags || runtimeConfig.public.featureFlags || {}
+  
+  return flags
 })

--- a/src/runtime/server/utils/feature-flags.ts
+++ b/src/runtime/server/utils/feature-flags.ts
@@ -3,7 +3,17 @@ import featureFlagConfig from '#feature-flags/config'
 import type { FlagsSchema } from '#feature-flags/types'
 
 export function getFeatureFlags(event: H3Event) {
-  const { flags = {} } = featureFlagConfig(event.context) as FlagsSchema
+  // Handle both function-based configs and static configs
+  let flags: FlagsSchema
+  
+  if (typeof featureFlagConfig === 'function') {
+    // Config file with defineFeatureFlags
+    flags = featureFlagConfig(event.context) as FlagsSchema || {}
+  }
+  else {
+    // Static config or inline flags
+    flags = featureFlagConfig as FlagsSchema || {}
+  }
 
   return {
     flags,


### PR DESCRIPTION
- Fix issue where feature flags endpoint returns empty object
- Add proper handling for function-based configs from defineFeatureFlags
- Ensure context evaluation works correctly for dynamic flags
- Fixes #16