### PR TITLE
🔒 security: replace MD5 with SHA-256 for variant assignment

### DIFF
--- a/src/runtime/server/utils/variant-assignment.ts
+++ b/src/runtime/server/utils/variant-assignment.ts
@@ -46,7 +46,7 @@ export function normalizeWeights(variants: FlagVariant[]): NormalizedVariant[] {
 export function generateVariantHash(flagName: string, context: VariantContext): number {
   const identifier = context.userId || context.sessionId || context.ipAddress || 'anonymous'
   const input = `${flagName}:${identifier}`
-  const hash = createHash('md5').update(input).digest('hex')
+  const hash = createHash('sha256').update(input).digest('hex')
 
   // Convert first 8 characters of hex to number and normalize to 0-100
   const hashInt = Number.parseInt(hash.substring(0, 8), 16)

--- a/test/unit/variant-assignment-new.test.ts
+++ b/test/unit/variant-assignment-new.test.ts
@@ -165,7 +165,7 @@ describe('variant assignment', () => {
 
   describe('generateVariantHash', () => {
     it('should generate consistent hash for same input', () => {
-      mockDigest.mockReturnValue('5d41402abc4b2a76b9719d911017c592')
+      mockDigest.mockReturnValue('6b51d431df5d7f141cbececcf7b427ba')
 
       const context = { userId: 'user123' }
 
@@ -179,7 +179,7 @@ describe('variant assignment', () => {
       let callCount = 0
       mockDigest.mockImplementation(() => {
         callCount++
-        return callCount === 1 ? '5d41402abc4b2a76b9719d911017c592' : 'abcd1234efgh5678ijkl9012mnop3456'
+        return callCount === 1 ? '6b51d431df5d7f141cbececcf7b427ba' : 'abcd1234efgh5678ijkl9012mnop3456'
       })
 
       const context = { userId: 'user123' }
@@ -194,7 +194,7 @@ describe('variant assignment', () => {
       let callCount = 0
       mockDigest.mockImplementation(() => {
         callCount++
-        return callCount === 1 ? '5d41402abc4b2a76b9719d911017c592' : 'abcd1234efgh5678ijkl9012mnop3456'
+        return callCount === 1 ? '6b51d431df5d7f141cbececcf7b427ba' : 'abcd1234efgh5678ijkl9012mnop3456'
       })
 
       const hash1 = generateVariantHash('test-flag', { userId: 'user1' })
@@ -204,7 +204,7 @@ describe('variant assignment', () => {
     })
 
     it('should fallback to sessionId when userId is not available', () => {
-      mockDigest.mockReturnValue('5d41402abc4b2a76b9719d911017c592')
+      mockDigest.mockReturnValue('6b51d431df5d7f141cbececcf7b427ba')
 
       const context = { sessionId: 'session123' }
 
@@ -215,7 +215,7 @@ describe('variant assignment', () => {
     })
 
     it('should fallback to ipAddress when userId and sessionId are not available', () => {
-      mockDigest.mockReturnValue('5d41402abc4b2a76b9719d911017c592')
+      mockDigest.mockReturnValue('6b51d431df5d7f141cbececcf7b427ba')
 
       const context = { ipAddress: '192.168.1.1' }
 
@@ -226,7 +226,7 @@ describe('variant assignment', () => {
     })
 
     it('should use anonymous fallback when no context is available', () => {
-      mockDigest.mockReturnValue('5d41402abc4b2a76b9719d911017c592')
+      mockDigest.mockReturnValue('6b51d431df5d7f141cbececcf7b427ba')
 
       const context = {}
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR replaces the weak MD5 hashing algorithm with the more secure SHA-256 algorithm in the `generateVariantHash` utility, which is used for persistent A/B testing variant assignment.

### ⚠️ Risk: The potential impact if left unfixed
MD5 is considered cryptographically broken and should not be used in modern applications. While variant assignment isn't a high-stakes cryptographic use case, using MD5 can trigger security audits and compliance failures. Additionally, it's a best practice to use stronger hashing algorithms like SHA-256 to avoid collision risks.

### 🛡️ Solution: How the fix addresses the vulnerability
The `generateVariantHash` function now uses `createHash('sha256')` instead of `createHash('md5')`. The resulting hex digest is truncated to the first 8 characters, which are then converted to a 32-bit integer for modulo operation. This provides a stable, uniform distribution for variant assignment using a secure algorithm.

**Note:** This change will result in a one-time re-shuffling of variant assignments for existing users/sessions due to the change in hash values.

---
*PR created automatically by Jules for task [12533968541474618297](https://jules.google.com/task/12533968541474618297) started by @roberthgnz*