### PR TITLE
🧪 Add unit tests for defineFeatureFlags

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,8 @@ export interface FlagConfig {
 export type FlagsSchema = Record<string, FlagValue | FlagConfig>
 
 // Type for the function that defines feature flags, which can be sync or async
-export type FeatureFlagsConfig =
-  | FlagsSchema
+export type FeatureFlagsConfig
+  = FlagsSchema
   | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
 
 // Type for the resolved flag after processing

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,7 @@ export interface FlagConfig {
 export type FlagsSchema = Record<string, FlagValue | FlagConfig>
 
 // Type for the function that defines feature flags, which can be sync or async
-export type FeatureFlagsConfig
-    = FlagsSchema
-    | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
+export type FeatureFlagsConfig = FlagsSchema | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
 
 // Type for the resolved flag after processing
 export interface ResolvedFlag {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,8 @@ export type FlagsSchema = Record<string, FlagValue | FlagConfig>
 
 // Type for the function that defines feature flags, which can be sync or async
 export type FeatureFlagsConfig
-  = FlagsSchema
-  | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
+    = FlagsSchema
+    | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
 
 // Type for the resolved flag after processing
 export interface ResolvedFlag {

--- a/test/unit/define-feature-flags.test.ts
+++ b/test/unit/define-feature-flags.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { defineFeatureFlags } from '~/src/runtime/server/handlers/feature-flags'
+import type { ConfigContext } from '~/src/runtime/server/handlers/feature-flags'
+
+describe('defineFeatureFlags', () => {
+  it('should return the passed callback function (identity)', () => {
+    const callback = () => ({ flag: true })
+    const result = defineFeatureFlags(callback)
+    expect(result).toBe(callback)
+  })
+
+  it('should return a function that produces expected flags when called', () => {
+    const flags = { myFlag: true }
+    const callback = () => flags
+    const result = defineFeatureFlags(callback)
+    expect(result()).toEqual(flags)
+  })
+
+  it('should support asynchronous callbacks', async () => {
+    const flags = { asyncFlag: 'value' }
+    const callback = async () => flags
+    const result = defineFeatureFlags(callback)
+    const resolvedFlags = await result()
+    expect(resolvedFlags).toEqual(flags)
+  })
+
+  it('should pass context to the callback correctly', () => {
+    const callback = (context?: ConfigContext | any) => ({
+      isDev: context?.isDev ?? false,
+    })
+    const result = defineFeatureFlags(callback)
+
+    expect(result({ isDev: true } as ConfigContext)).toEqual({ isDev: true })
+    expect(result({ isDev: false } as ConfigContext)).toEqual({ isDev: false })
+    expect(result()).toEqual({ isDev: false })
+  })
+})

--- a/test/unit/define-feature-flags.test.ts
+++ b/test/unit/define-feature-flags.test.ts
@@ -25,8 +25,8 @@ describe('defineFeatureFlags', () => {
   })
 
   it('should pass context to the callback correctly', () => {
-    const callback = (context?: ConfigContext | any) => ({
-      isDev: context?.isDev ?? false,
+    const callback = (context?: ConfigContext | Record<string, unknown>) => ({
+      isDev: (context as ConfigContext | undefined)?.isDev ?? false,
     })
     const result = defineFeatureFlags(callback)
 


### PR DESCRIPTION
🎯 **What:** Missing test for `defineFeatureFlags` in `src/runtime/server/handlers/feature-flags.ts`.
📊 **Coverage:** Added tests for identity property, callback execution, async support, and context passing.
✨ **Result:** Improved test coverage and reliability for the core configuration helper.

Manual verification was performed using a standalone Node script because `vitest` was unavailable in the sandbox environment.

---
*PR created automatically by Jules for task [7618517055480777838](https://jules.google.com/task/7618517055480777838) started by @roberthgnz*