### PR TITLE
🧹 Refactor: Remove unnecessary wrapper in API handler

### DIFF
--- a/src/runtime/server/api/feature-flags.get.ts
+++ b/src/runtime/server/api/feature-flags.get.ts
@@ -1,7 +1,4 @@
 import { eventHandler } from 'h3'
 import { resolveFeatureFlags } from '../utils/feature-flags'
 
-export default eventHandler(async (event) => {
-  const flags = await resolveFeatureFlags(event)
-  return flags
-})
+export default eventHandler(resolveFeatureFlags)

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,8 @@ export interface FlagConfig {
 export type FlagsSchema = Record<string, FlagValue | FlagConfig>
 
 // Type for the function that defines feature flags, which can be sync or async
-export type FeatureFlagsConfig =
-  | FlagsSchema
+export type FeatureFlagsConfig
+  = FlagsSchema
   | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
 
 // Type for the resolved flag after processing

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,7 @@ export interface FlagConfig {
 export type FlagsSchema = Record<string, FlagValue | FlagConfig>
 
 // Type for the function that defines feature flags, which can be sync or async
-export type FeatureFlagsConfig
-  = FlagsSchema
-  | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
+export type FeatureFlagsConfig = FlagsSchema | ((context?: H3EventContext) => FlagsSchema | Promise<FlagsSchema>)
 
 // Type for the resolved flag after processing
 export interface ResolvedFlag {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed an unnecessary anonymous async function wrapper in the `feature-flags.get.ts` API handler.

💡 **Why:** How this improves maintainability
Passing the utility function directly is cleaner, more idiomatic for `h3`/Nuxt handlers, and slightly more performant as it avoids an extra function call and promise wrapping.

✅ **Verification:** How you confirmed the change is safe
- Verified syntax with `node --check`.
- Performed a manual code review.
- Received a positive code review confirming the refactoring is logically equivalent and follows standard practices.
- Attempted to run the test suite, though local environment constraints (missing `node_modules` and network isolation) prevented full execution.

✨ **Result:** The improvement achieved
A more concise and idiomatic API handler implementation.

---
*PR created automatically by Jules for task [3453359930783849203](https://jules.google.com/task/3453359930783849203) started by @roberthgnz*